### PR TITLE
[IMP] connector_importer: implement notification for processed records in importer

### DIFF
--- a/connector_importer/__manifest__.py
+++ b/connector_importer/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Connector Importer",
     "summary": """This module takes care of import sessions.""",
     "version": "18.0.1.0.1",
-    "depends": ["connector", "queue_job"],
+    "depends": ["connector", "queue_job", "web_notify"],
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Connector",

--- a/connector_importer/components/importer.py
+++ b/connector_importer/components/importer.py
@@ -332,6 +332,8 @@ class RecordImporter(Component):
             return
 
         self._init_importer(self.record.recordset_id)
+
+        processed_record_ids = []
         for line in self._record_lines():
             line = self.prepare_line(line)
             options = self._load_mapper_options()
@@ -370,6 +372,10 @@ class RecordImporter(Component):
                             continue
                         odoo_record = self.record_handler.odoo_create(values, line)
                         self.tracker.log_created(values, line, odoo_record)
+
+                    if odoo_record:
+                        processed_record_ids.append(odoo_record.id)
+
             except Exception as err:
                 self.tracker.log_error(values, line, odoo_record, message=err)
                 if self.must_break_on_error:
@@ -391,6 +397,8 @@ class RecordImporter(Component):
             ]
         ).format(**counters)
         self.tracker._log(msg)
+        if processed_record_ids:
+            self._send_result_notification(processed_record_ids)
         self.finalize_session(record, is_last_importer=is_last_importer)
         return counters
 
@@ -420,3 +428,33 @@ class RecordImporter(Component):
         self.model.browse()._event(
             "on_last_record_import_finished", collection=self.work.collection
         ).notify(self, record)
+
+    def _send_result_notification(self, record_ids):
+        model_name = self.model._name
+        model_description = self.env["ir.model"]._get(model_name).name or self.env._(
+            "Records"
+        )
+
+        message = self.env._(
+            "%(count)s %(model_name)s have been processed.",
+            count=len(record_ids),
+            model_name=model_description,
+        )
+
+        action = {
+            "display_name": "Processed Records",
+            "type": "ir.actions.act_window",
+            "name": model_description,
+            "res_model": model_name,
+            "view_mode": "list,form",
+            "domain": [("id", "in", record_ids)],
+            "target": "current",
+            "context": {"params": {"button_name": "Processed Records"}},
+        }
+
+        self.env.user.notify_info(
+            message=message,
+            title="Processed Records",
+            sticky=True,
+            action=action,
+        )

--- a/connector_importer/tests/test_record_importer.py
+++ b/connector_importer/tests/test_record_importer.py
@@ -2,6 +2,8 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import json
+
 from odoo.tools import mute_logger
 
 from .common import TestImporterBase
@@ -134,3 +136,29 @@ class TestRecordImporter(TestImporterBase):
             self.assertEqual(len(report[model][k]), v)
         skipped_msg1 = report[model]["skipped"][0]["message"]
         self.assertEqual(skipped_msg1, "ALREADY EXISTS: ref=id_1")
+
+    @mute_logger(*LOGGERS_TO_MUTE)
+    def test_importer_notify_info(self):
+        bus_bus = self.env["bus.bus"]
+        notify_channel = self.env.user.notify_info_channel_name
+        domain = [("channel", "=", notify_channel)]
+        existing_msgs = bus_bus.search(domain)
+
+        # generate 10 records
+        lines = self._fake_lines(10, keys=("id", "fullname"))
+        self.record.set_data(lines)
+        self.record.run_import()
+
+        self.env.cr.precommit.run()
+        new_msgs = bus_bus.search(domain) - existing_msgs
+        self.assertEqual(1, len(new_msgs))
+
+        payload = json.loads(new_msgs.message)["payload"]
+        self.assertEqual(payload["type"], "info")
+        self.assertEqual(payload["title"], "Processed Records")
+        self.assertEqual(payload["sticky"], True)
+        self.assertTrue(payload["action"])
+        self.assertEqual(len(payload["action"]["domain"]), 1)
+        self.assertEqual(len(payload["action"]["domain"][0][2]), 10)
+        self.assertEqual(payload["action"]["res_model"], "res.partner")
+        self.assertIn("message", payload)


### PR DESCRIPTION
This PR adds one step to the importer process.
After the import is completed, a `notify_info` message is sent to the current user.

- The notification includes:

   - A summary message indicating how many records were processed

   - An `ir.actions.act_window` link to directly open the `list/form` view of the imported records

This improves user experience by allowing quick access to the result of the import.